### PR TITLE
Record diaper daily stats and refine dashboard

### DIFF
--- a/dashboards/diaper_dashboard.yaml
+++ b/dashboards/diaper_dashboard.yaml
@@ -62,11 +62,12 @@ views:
 
       - type: statistics-graph
         title: Diapers per day (30 days)
-        days_to_show: 30
-        chart_type: bar
-        stat_types: [ max ]
         entities:
           - sensor.diaper_daily
+        stat_types: [sum]
+        period: day
+        days_to_show: 30
+        chart_type: bar
 
       - type: markdown
         title: Last 5 diapers

--- a/packages/diaper/diaper.yaml
+++ b/packages/diaper/diaper.yaml
@@ -2,6 +2,12 @@
 # Diaper tracking package (shareable, robust)
 # =========================
 
+# --- Recorder ---
+recorder:
+  include:
+    entities:
+      - sensor.diaper_daily
+
 # --- Helpers / Inputs ---
 input_number:
   diaper_bag_capacity:


### PR DESCRIPTION
## Summary
- include `sensor.diaper_daily` in recorder to preserve daily totals
- show daily diaper totals with summed bar chart on dashboard

## Testing
- `yamllint dashboards/diaper_dashboard.yaml packages/diaper/diaper.yaml` *(fails: missing document start, line length, spacing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f2b73ea483238e416035ff5eb94a