### PR TITLE
Handle zero diaper usage rate in days-to-full sensor

### DIFF
--- a/packages/diaper/diaper.yaml
+++ b/packages/diaper/diaper.yaml
@@ -161,12 +161,15 @@ template:
         unit_of_measurement: d
         icon: mdi:calendar-clock
         state: >
-          {% set rate = states('sensor.diapers_per_day_last_3_completed_days_avg')|float(0) %}
-          {% if rate == 0 %} unknown
+          {% set avg = states('sensor.diapers_per_day_last_3_completed_days_avg')|float(0) %}
+          {% if avg > 0 %}
+            {% set rate = avg %}
           {% else %}
-            {% set remain = states('sensor.diaper_bag_remaining')|float(0) %}
-            {{ (remain / rate) | round(2) }}
+            {% set last = state_attr('sensor.diaper_daily','last_period')|float(0) %}
+            {% set rate = last if last > 0 else 0.01 %}
           {% endif %}
+          {% set remain = states('sensor.diaper_bag_remaining')|float(0) %}
+          {{ (remain / rate) | round(2) }}
 
       - name: Diaper Next Full ETA
         unique_id: diaper_next_full_eta


### PR DESCRIPTION
## Summary
- Prevent `sensor.diaper_days_to_full` from returning `unknown` by falling back to the last daily count or a minimal rate when the 3-day average is zero

## Testing
- `yamllint packages/diaper/diaper.yaml` *(fails: line-length and spacing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f2b645a4832391ff6071f949682d