### PR TITLE
Initialize diaper text helpers with empty defaults

### DIFF
--- a/packages/diaper/diaper.yaml
+++ b/packages/diaper/diaper.yaml
@@ -46,9 +46,11 @@ input_text:
   diaper_recent_times:
     name: Diaper Recent Times (last 5 ISO)
     max: 255
+    initial: ""
   diaper_daily_last3:
     name: Diaper Daily Last 3 (completed days)
     max: 64
+    initial: ""
 
 input_datetime:
   last_diaper_time:


### PR DESCRIPTION
## Summary
- ensure diaper history helpers start empty rather than `unknown`

## Testing
- `yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable}}' packages/diaper/diaper.yaml` *(fails: too many spaces inside braces)*
- `ha core restart` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f2b41e148323a0c20a0cc8088d2e