### PR TITLE
Fix default block for diaper undo script

### DIFF
--- a/packages/diaper/diaper.yaml
+++ b/packages/diaper/diaper.yaml
@@ -302,10 +302,10 @@ script:
               - service: input_datetime.set_datetime
                 target: { entity_id: input_datetime.last_diaper_time }
                 data: { datetime: "{{ as_timestamp(as_datetime(remaining[0])) | timestamp_local }}" }
-          - default:
-              - service: input_datetime.set_datetime
-                target: { entity_id: input_datetime.last_diaper_time }
-                data: { datetime: "1970-01-01 00:00:00" }
+        default:
+          - service: input_datetime.set_datetime
+            target: { entity_id: input_datetime.last_diaper_time }
+            data: { datetime: "1970-01-01 00:00:00" }
       - service: persistent_notification.create
         data:
           title: "Diaper - Undo Last"


### PR DESCRIPTION
## Summary
- make default a sibling of choose in diaper_undo_last script

## Testing
- `yamllint packages/diaper/diaper.yaml` *(fails: multiple line-length and brace style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f2b330588323b0738bbd9aa49488