### PR TITLE
Use daily max for diaper stats graph

### DIFF
--- a/dashboards/diaper_dashboard.yaml
+++ b/dashboards/diaper_dashboard.yaml
@@ -64,7 +64,7 @@ views:
         title: Diapers per day (30 days)
         entities:
           - sensor.diaper_daily
-        stat_types: [sum]
+        stat_types: [max]
         period: day
         days_to_show: 30
         chart_type: bar


### PR DESCRIPTION
## Summary
- show final daily diaper count using `stat_types: [max]`

## Testing
- `yamllint dashboards/diaper_dashboard.yaml` *(fails: missing document start, spacing and line length issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fdac11c88323867d0283cb30aba3