### PR TITLE
Fix diaper scripts undo and clean slate errors

### DIFF
--- a/packages/diaper/diaper.yaml
+++ b/packages/diaper/diaper.yaml
@@ -210,7 +210,17 @@ script:
             - sensor.diaper_*
             - counter.diaper_count
           keep_days: 0
+      - service: recorder.purge
+        data:
+          keep_days: 0
           repack: true
+          apply_to_entities:
+            - sensor.diaper_bag
+            - sensor.diaper_daily
+            - sensor.diaper_weekly
+            - sensor.diaper_monthly
+            - sensor.diaper_tod
+            - counter.diaper_count
       - service: input_text.set_value
         target: { entity_id: input_text.diaper_recent_times }
         data: { value: "" }
@@ -248,9 +258,9 @@ script:
           in_week: "{{ popped_dt is not none and as_timestamp(popped_dt) >= week_start }}"
           in_month: "{{ popped_dt is not none and as_timestamp(popped_dt) >= month_start }}"
           in_bag: "{{ popped_dt is not none and bag_start is not none and as_timestamp(popped_dt) >= as_timestamp(bag_start) }}"
-          popped_hour: "{{ (popped_dt.hour if popped_dt is not none else 0) }}"
+          popped_hour: "{{ (popped_dt.hour if popped_dt is not none else 0) | int }}"
           popped_bucket: >
-            {% set h = popped_hour %}
+            {% set h = popped_hour | int %}
             {% if 0 <= h < 6 %}Night
             {% elif 6 <= h < 12 %}Morning
             {% elif 12 <= h < 18 %}Afternoon


### PR DESCRIPTION
## Summary
- fix undo script by casting popped hour to int
- replace invalid repack key in clean slate script and repack safely

## Testing
- `yamllint -d "{extends: default, rules: {line-length: disable, document-start: disable, braces: disable}}" packages/diaper/diaper.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68a5ff1442e48323bc8488c8d818d91f