### PR TITLE
Fix recorder purge error in clean slate script

### DIFF
--- a/packages/diaper/diaper.yaml
+++ b/packages/diaper/diaper.yaml
@@ -214,13 +214,6 @@ script:
         data:
           keep_days: 0
           repack: true
-          apply_to_entities:
-            - sensor.diaper_bag
-            - sensor.diaper_daily
-            - sensor.diaper_weekly
-            - sensor.diaper_monthly
-            - sensor.diaper_tod
-            - counter.diaper_count
       - service: input_text.set_value
         target: { entity_id: input_text.diaper_recent_times }
         data: { value: "" }


### PR DESCRIPTION
## Summary
- remove unsupported `apply_to_entities` from `recorder.purge` service call

## Testing
- `yamllint packages/diaper/diaper.yaml` *(fails: too many style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a61bb0ed748323ad45ec8fbaf95d24