### PR TITLE
Add open-state condition for diaper counter automation

### DIFF
--- a/packages/diaper/diaper.yaml
+++ b/packages/diaper/diaper.yaml
@@ -385,6 +385,8 @@ automation:
     condition:
       - condition: template
         value_template: "{{ trigger.to_state is not none and trigger.to_state.state in ['off','closed'] }}"
+      - condition: template
+        value_template: "{{ trigger.from_state is not none and trigger.from_state.state in ['on','open'] }}"
     action:
       - variables:
           now_iso: "{{ now().isoformat() }}"


### PR DESCRIPTION
## Summary
- require the sensor to have been open/on before counting a diaper

## Testing
- `ha core check` *(fails: command not found)*
- `curl -v -X POST -H "Authorization: Bearer fake" -H "Content-Type: application/json" http://localhost:8123/api/services/automation/reload` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a0655cf08323a0687e998e498acc