### PR TITLE
refactor: use neutral units for diaper sensors

### DIFF
--- a/dashboards/diaper_dashboard.yaml
+++ b/dashboards/diaper_dashboard.yaml
@@ -20,7 +20,7 @@ views:
           - entity: sensor.diaper_bag_remaining
             name: Remaining in bag
           - entity: input_number.diaper_bag_capacity
-            name: Capacity (pcs)
+            name: Capacity (items)
           - entity: input_datetime.last_diaper_time
             name: Last registered
           - entity: sensor.diapers_per_day_last_3_completed_days_avg
@@ -61,7 +61,7 @@ views:
             name: Evening
 
       - type: statistics-graph
-        title: Diapers per day (30 days)
+        title: Items per day (30 days)
         entities:
           - sensor.diaper_daily
         stat_types: [max]

--- a/packages/diaper/diaper.yaml
+++ b/packages/diaper/diaper.yaml
@@ -15,7 +15,7 @@ input_number:
     min: 5
     max: 100
     step: 1
-    unit_of_measurement: diapers
+    unit_of_measurement: items
     initial: 22
     icon: mdi:trash-can
     mode: box
@@ -110,20 +110,20 @@ template:
   - sensor:
       - name: Diaper Total
         unique_id: diaper_total
-        unit_of_measurement: diapers
+        unit_of_measurement: items
         state_class: total_increasing
         state: "{{ states('counter.diaper_count') | int(0) }}"
 
       - name: Diaper Bag Used
         unique_id: diaper_bag_used
-        unit_of_measurement: diapers
+        unit_of_measurement: items
         state: >
           {% set v = states('sensor.diaper_bag') %}
           {% if v in ['unknown','unavailable',''] %} 0 {% else %} {{ v|int(0) }} {% endif %}
 
       - name: Diaper Bag Remaining
         unique_id: diaper_bag_remaining
-        unit_of_measurement: diapers
+        unit_of_measurement: items
         state: >
           {% set cap = states('input_number.diaper_bag_capacity')|int(22) %}
           {% set used = states('sensor.diaper_bag_used')|int(0) %}
@@ -140,13 +140,13 @@ template:
 
       - name: Diapers Yesterday
         unique_id: diapers_yesterday
-        unit_of_measurement: diapers
+        unit_of_measurement: items
         state_class: measurement
         state: "{{ state_attr('sensor.diaper_daily','last_period') | int(0) }}"
 
       - name: Diapers per Day (Last 3 Completed Days Avg)
         unique_id: diapers_per_day_last_3_completed_days_avg
-        unit_of_measurement: diapers/day
+        unit_of_measurement: items/day
         state: >
           {% set raw = states('input_text.diaper_daily_last3') %}
           {% set arr = [] if raw in ['unknown','unavailable',''] else (raw.split('|') | map('int') | list) %}


### PR DESCRIPTION
## Summary
- switch diaper package units from `diapers` to neutral `items`
- update dashboard capacity and graph labels to `items`

## Testing
- `yamllint packages/diaper/diaper.yaml dashboards/diaper_dashboard.yaml` *(fails: line-length and brace spacing errors)*
- `ha core restart` *(fails: command not found)*
- `hass --script check_config -c .` *(fails: File configuration.yaml not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a06d246c83238857bfdb7e03466f