### PR TITLE
feat: track bin open close times

### DIFF
--- a/dashboards/diaper_dashboard.yaml
+++ b/dashboards/diaper_dashboard.yaml
@@ -33,6 +33,15 @@ views:
             name: Auto-calibrate capacity
 
       - type: entities
+        title: Bin Activity
+        show_header_toggle: false
+        entities:
+          - entity: input_datetime.diaper_bin_last_opened
+            name: Last opened
+          - entity: input_datetime.diaper_bin_last_closed
+            name: Last closed
+
+      - type: entities
         title: Totals
         show_header_toggle: false
         entities:

--- a/packages/diaper/diaper.yaml
+++ b/packages/diaper/diaper.yaml
@@ -75,6 +75,14 @@ input_datetime:
     name: Diaper Bag Started (previous)
     has_date: true
     has_time: true
+  diaper_bin_last_opened:
+    name: Diaper Bin Last Opened
+    has_date: true
+    has_time: true
+  diaper_bin_last_closed:
+    name: Diaper Bin Last Closed
+    has_date: true
+    has_time: true
 
 counter:
   diaper_count:
@@ -395,6 +403,9 @@ automation:
             {% elif 12 <= h < 18 %}Afternoon
             {% else %}Evening
             {% endif %}
+      - service: input_datetime.set_datetime
+        target: { entity_id: input_datetime.diaper_bin_last_closed }
+        data: { datetime: "{{ now().timestamp() | timestamp_local }}" }
       - service: select.select_option
         target: { entity_id: select.diaper_tod }
         data: { option: "{{ bucket }}" }
@@ -418,6 +429,21 @@ automation:
           name: "Diaper disposed"
           message: "Added {{ now_iso }}"
           entity_id: input_text.diaper_recent_times
+
+  - alias: Diaper - Record Bin Opened
+    id: diaper_record_bin_opened
+    mode: single
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.bleiebotte_contact   # adjust to your sensor id
+        to: 'on'
+      - platform: state
+        entity_id: binary_sensor.bleiebotte_contact   # adjust to your sensor id
+        to: 'open'
+    action:
+      - service: input_datetime.set_datetime
+        target: { entity_id: input_datetime.diaper_bin_last_opened }
+        data: { datetime: "{{ now().timestamp() | timestamp_local }}" }
 
   - alias: Diaper - Reset Bag Counter on Take-Out
     id: diaper_reset_bag_counter_on_takeout


### PR DESCRIPTION
## Summary
- track last diaper bin open and close timestamps
- show diaper bin activity on the dashboard
- unnest input_datetime definitions

## Testing
- `yamllint -d "{extends: default, rules: {line-length: disable, braces: disable, document-start: disable}}" packages/diaper/diaper.yaml dashboards/diaper_dashboard.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68a89da577d4832392b87faf1d063938