### PR TITLE
feat: show bin activity history

### DIFF
--- a/dashboards/diaper_dashboard.yaml
+++ b/dashboards/diaper_dashboard.yaml
@@ -32,14 +32,11 @@ views:
           - entity: input_boolean.diaper_auto_calibrate_capacity
             name: Auto-calibrate capacity
 
-      - type: entities
-        title: Bin Activity
-        show_header_toggle: false
+      - type: state-history
+        title: Bin Activity (24h)
         entities:
-          - entity: input_datetime.diaper_bin_last_opened
-            name: Last opened
-          - entity: input_datetime.diaper_bin_last_closed
-            name: Last closed
+          - binary_sensor.bleiebotte_contact
+        hours_to_show: 24
 
       - type: entities
         title: Totals


### PR DESCRIPTION
## Summary
- replace bin activity card with 24h state history histogram

## Testing
- `yamllint dashboards/diaper_dashboard.yaml` *(fails: missing document start, braces spacing, line-length)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9b779ef083238106cb1bbc2c7557