### PR TITLE
Fix daily history roll template splitting error

### DIFF
--- a/packages/diaper/diaper.yaml
+++ b/packages/diaper/diaper.yaml
@@ -510,8 +510,8 @@ automation:
     action:
       - variables:
           yest: "{{ state_attr('sensor.diaper_daily','last_period') | int(0) }}"
-          raw: "{{ states('input_text.diaper_daily_last3') | string }}"
-          arr: "{{ [] if raw in ['unknown','unavailable',''] else (raw.split('|') | map('int') | list) }}"
+          raw: "{{ states('input_text.diaper_daily_last3') | default('', true) }}"
+          arr: "{{ [] if raw in ['unknown','unavailable',''] else ((raw | string).split('|') | map('int') | list) }}"
           updated: >
             {% set new = [yest] + arr %}
             {% set trimmed = new[:3] %}


### PR DESCRIPTION
## Summary
- prevent `split` on non-string values when rolling diaper daily history
- default missing history text to empty string

## Testing
- `yamllint packages/diaper/diaper.yaml` *(fails: line-length and brace spacing violations)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9dffbae0832380fdc89f11905b23