### PR TITLE
Add delay to ignore rapid diaper bin triggers

### DIFF
--- a/blueprints/automation/smartdiaperbin/diaper_count_on_close.yaml
+++ b/blueprints/automation/smartdiaperbin/diaper_count_on_close.yaml
@@ -56,3 +56,4 @@ action:
   - service: input_text.set_value
     target: { entity_id: !input recent_times }
     data: { value: "{{ updated }}" }
+  - delay: '00:01:00'

--- a/packages/diaper/diaper.yaml
+++ b/packages/diaper/diaper.yaml
@@ -16,7 +16,6 @@ input_number:
     max: 100
     step: 1
     unit_of_measurement: items
-    initial: 22
     icon: mdi:trash-can
     mode: box
 
@@ -52,11 +51,9 @@ input_text:
   diaper_recent_times:
     name: Diaper Recent Times (last 5 ISO)
     max: 255
-    initial: ""
   diaper_daily_last3:
     name: Diaper Daily Last 3 (completed days)
     max: 64
-    initial: ""
 
 input_datetime:
   last_diaper_time:
@@ -426,14 +423,15 @@ automation:
             {% set new = [now_iso] + arr %}
             {% set trimmed = new[:5] %}
             {{ trimmed | join('|') }}
-      - service: input_text.set_value
-        target: { entity_id: input_text.diaper_recent_times }
-        data: { value: "{{ updated }}" }
-      - service: logbook.log
-        data:
-          name: "Diaper disposed"
-          message: "Added {{ now_iso }}"
-          entity_id: input_text.diaper_recent_times
+        - service: input_text.set_value
+          target: { entity_id: input_text.diaper_recent_times }
+          data: { value: "{{ updated }}" }
+        - service: logbook.log
+          data:
+            name: "Diaper disposed"
+            message: "Added {{ now_iso }}"
+            entity_id: input_text.diaper_recent_times
+        - delay: '00:01:00'
 
   - alias: Diaper - Record Bin Opened
     id: diaper_record_bin_opened


### PR DESCRIPTION
## Summary
- ensure diaper counting automation ignores rapid successive lid events by waiting 60 seconds after each trigger
- prevent diaper bag capacity and recent-time helpers from resetting on restart so values persist

## Testing
- `yamllint blueprints/automation/smartdiaperbin/diaper_count_on_close.yaml packages/diaper/diaper.yaml` *(fails: line-length and formatting errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bda4e39e6c8323b288958e33126c2b