### PR TITLE
Fix indentation in diaper automation

### DIFF
--- a/packages/diaper/diaper.yaml
+++ b/packages/diaper/diaper.yaml
@@ -423,15 +423,15 @@ automation:
             {% set new = [now_iso] + arr %}
             {% set trimmed = new[:5] %}
             {{ trimmed | join('|') }}
-        - service: input_text.set_value
-          target: { entity_id: input_text.diaper_recent_times }
-          data: { value: "{{ updated }}" }
-        - service: logbook.log
-          data:
-            name: "Diaper disposed"
-            message: "Added {{ now_iso }}"
-            entity_id: input_text.diaper_recent_times
-        - delay: '00:01:00'
+      - service: input_text.set_value
+        target: { entity_id: input_text.diaper_recent_times }
+        data: { value: "{{ updated }}" }
+      - service: logbook.log
+        data:
+          name: "Diaper disposed"
+          message: "Added {{ now_iso }}"
+          entity_id: input_text.diaper_recent_times
+      - delay: '00:01:00'
 
   - alias: Diaper - Record Bin Opened
     id: diaper_record_bin_opened


### PR DESCRIPTION
## Summary
- fix indentation for recent diaper time logging actions

## Testing
- `yamllint packages/diaper/diaper.yaml` *(fails: many pre-existing lint errors but no YAML syntax error at line 426)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c9069b1c83239e38e7f00178641d