### PR TITLE
Add optional pause helpers to empty bag reset blueprint

### DIFF
--- a/blueprints/automation/smartdiaperbin/diaper_empty_reset.yaml
+++ b/blueprints/automation/smartdiaperbin/diaper_empty_reset.yaml
@@ -1,6 +1,6 @@
 blueprint:
   name: Diaper Tracker – Empty Bag Reset
-  description: Save previous start, reset bag utility meter, set new start. (No TTS.)
+  description: Save previous start, reset bag utility meter, set new start, and optionally trigger the pause helpers. (No TTS.)
   domain: automation
   input:
     reset_button:
@@ -15,6 +15,14 @@ blueprint:
     started_prev:
       name: Input datetime – bag started (previous)
       selector: { entity: { domain: input_datetime } }
+    pause_flag:
+      name: (Optional) Pause helper boolean
+      selector: { entity: { domain: input_boolean } }
+      default: ""
+    pause_timer:
+      name: (Optional) Pause timer
+      selector: { entity: { domain: timer } }
+      default: ""
 
 mode: single
 trigger:
@@ -23,6 +31,24 @@ trigger:
 action:
   - variables:
       prev_start: "{{ states('!input started_now') }}"
+      pause_flag: !input pause_flag
+      pause_timer: !input pause_timer
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ pause_flag not in [none, ''] }}"
+        sequence:
+          - service: input_boolean.turn_on
+            data:
+              entity_id: "{{ pause_flag }}"
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ pause_timer not in [none, ''] }}"
+        sequence:
+          - service: timer.start
+            data:
+              entity_id: "{{ pause_timer }}"
   - service: input_datetime.set_datetime
     target: { entity_id: !input started_prev }
     data:


### PR DESCRIPTION
## Summary
- add optional pause helper inputs to the empty bag reset blueprint
- trigger the pause boolean and timer when provided so the 2-minute lockout starts from inline automation
- document the optional pause behavior in the blueprint description

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc10d80dc48323ae38076faac61b3e